### PR TITLE
Release v0.2

### DIFF
--- a/com.todd.streamdeckcodex.sdPlugin/manifest.json
+++ b/com.todd.streamdeckcodex.sdPlugin/manifest.json
@@ -258,5 +258,5 @@
   "SupportURL": "https://github.com/twidtwid/streamdeckcodex/issues",
   "URL": "https://github.com/twidtwid/streamdeckcodex",
   "UUID": "com.todd.streamdeckcodex",
-  "Version": "0.1.0.0"
+  "Version": "0.2.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "streamdeck-codex-companion",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "streamdeck-codex-companion",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamdeck-codex-companion",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Independent Stream Deck companion for the Codex desktop app.",

--- a/test/build-pipeline.test.ts
+++ b/test/build-pipeline.test.ts
@@ -6,8 +6,12 @@ import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+  version: string;
   scripts: Record<string, string>;
 };
+const manifest = JSON.parse(
+  readFileSync("com.todd.streamdeckcodex.sdPlugin/manifest.json", "utf8"),
+) as { Version: string };
 const temporaryRoots: string[] = [];
 
 afterEach(() => {
@@ -17,6 +21,10 @@ afterEach(() => {
 });
 
 describe("non-repeating check pipeline", () => {
+  it("keeps the package and four-part Stream Deck versions aligned", () => {
+    expect(manifest.Version).toBe(`${packageJson.version}.0`);
+  });
+
   it("checks generated sources, builds native once, and uses a pretest-free unit stage", () => {
     const check = packageJson.scripts.check!;
     expect(check).toBe(


### PR DESCRIPTION
## Summary
- align package version to 0.2.0
- align Stream Deck plugin version to 0.2.0.0
- enforce package/manifest version parity in tests

## Verification
- npm run release:verify
- 497 tests passed
- zero dependency audit findings
- package, docs, visuals, and Elgato validation passed